### PR TITLE
Make it serve src contents as a GitHub page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# GitHub Pages branch
+gh-pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "webxr-first-steps",
 	"private": true,
+	"homepage": "https://ZacharyEllison.github.io/vrps",
 	"devDependencies": {
 		"@types/three": "0.165.0",
 		"copy-webpack-plugin": "12.0.2",
@@ -16,12 +17,14 @@
 	"scripts": {
 		"build": "webpack",
 		"dev": "webpack serve",
-		"format": "prettier --write ./src/**/*"
+		"format": "prettier --write ./src/**/*",
+		"predeploy": "npm run build",
+		"deploy": "gh-pages -d dist"
 	},
 	"dependencies": {
 		"@iwer/devui": "0.1.1",
 		"gamepad-wrapper": "1.3.4",
-		"gsap": "3.12.5",
+			"gsap": "3.12.5",
 		"iwer": "1.0.4",
 		"three": "0.165.0",
 		"troika-three-text": "0.49.1"


### PR DESCRIPTION
Add GitHub Pages deployment configuration to `package.json` and update `.gitignore`.

* **package.json**
  - Add `"homepage": "https://ZacharyEllison.github.io/vrps"` to specify the GitHub Pages URL.
  - Add `"predeploy": "npm run build"` to the `scripts` section to build the project before deployment.
  - Add `"deploy": "gh-pages -d dist"` to the `scripts` section to deploy the project to GitHub Pages.

* **.gitignore**
  - Add `gh-pages` to ignore the `gh-pages` branch created by the deployment script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ZacharyEllison/vrps/pull/1?shareId=adf347ae-b901-45d1-ab7a-bc8adfd5f5c0).